### PR TITLE
Disable credential manager asking for password

### DIFF
--- a/repo_searcher.py
+++ b/repo_searcher.py
@@ -110,7 +110,7 @@ def __search(
 
     try:
         logging.info(f"Cloning {repo_full_name}")
-        repo = Repo.clone_from(repo_url, repo_path)
+        repo = Repo.clone_from(repo_url, repo_path, multi_options=["--config credential.helper=''"])
         repo.git.checkout(repo_commit_hash)
         logging.info(
             f"Cloned {repo_full_name} and checkout to commit {repo_commit_hash}"


### PR DESCRIPTION
If git credentials manager is enabled (default on Windows), even if ask_password is unset, a UI is going to trigger asking for a password which blocks the thread until user intervention.

Disable the git credentials manager for project clones.